### PR TITLE
Remove non-essential files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "homepage": "https://github.com/mafintosh/generate-function",
   "devDependencies": {
     "tape": "^2.13.4"
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
The readme and license files are always included.
