### PR TITLE
Add toModule method for IIFE code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ function multiply (a, b) {
 
 function addAndMultiplyNumber (val) {
   const gen = genfun()
-  
+
   gen(`
     function (n) {
       if (typeof n !== 'number') {
@@ -57,8 +57,7 @@ function addAndMultiplyNumber (val) {
     }
   `)
 
-  // use gen.toString() if you want to see the generated source
-
+  // use gen.toString() if you want to see the generated function as a string
   return gen.toFunction({multiply})
 }
 
@@ -69,6 +68,30 @@ console.log('(3 + 2) * 2 =', addAndMultiply2(3))
 ```
 
 You can call `gen(src)` as many times as you want to append more source code to the function.
+
+## Compiling A Module
+
+If you need to compile a function as a standalone module, use `gen.toModule(scope)`. This method wraps the
+scope into an [IIFE](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression) and returns it as a string. This is useful for compiling webpack modules or browser bundles.
+
+```js
+var gen = genfun(`
+  function addXAndY() {
+    return x + y
+  }
+`)
+
+console.log(gen.toModule({ x: 9, y: 3 }))
+/** output:
+ *
+ * (function() {
+ * var x = 9;
+ * var y = 3;;
+ * return (function addXAndY() {
+ *   return x + y
+ * })})();
+ */
+```
 
 ## Variables
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var util = require('util')
 var isProperty = require('is-property')
+var jaystring = require('jaystring')
 
 var INDENT_START = /[\{\[]/
 var INDENT_END = /[\}\]]/
@@ -150,6 +151,22 @@ var genfun = function() {
 
   line.toString = function() {
     return lines.join('\n')
+  }
+
+  line.toModule = function(scope) {
+    if (!scope) scope = {}
+
+    Object.keys(line.scope).forEach(function (key) {
+      if (!scope[key]) scope[key] = line.scope[key]
+    })
+
+    var scopeSource = Object.entries(scope)
+      .map(function ([key, value]) {
+        return `var ${key} = ${jaystring(value)};`
+      })
+      .join('\n')
+
+    return `(function() {\n${scopeSource}\nreturn (${line})})();`
   }
 
   line.toFunction = function(scope) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "tape": "^4.9.1"
   },
   "dependencies": {
-    "is-property": "^1.0.2"
+    "is-property": "^1.0.2",
+    "jaystring": "^1.0.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -47,3 +47,18 @@ tape('generate property', function(t) {
 
   t.end()
 })
+
+tape('generate IIFE module', function(t) {
+  var gen = genfun
+  (`function foo() {`)
+    (`return v + 10`)
+  (`}`)
+
+  var expected = `(function() {
+var v = 10;
+return (${gen})})();`
+
+  var mod = gen.toModule({ v: 10 })
+  t.same(mod, expected)
+  t.end()
+})


### PR DESCRIPTION
Sometimes one needs the `scope` of a `.toFunction(scope)` call to be included in the generated output function's `toString()` method, but since we use `Function.apply`, those variables are hidden, meaning that the output of `gen.toFunction(scope).toString()` cannot be used as a standalone module.

This PR uses the `jaystring` module to stringify variables in `scope` and declare them inside the top level of an IIFE. The IIFE then returns `gen.toString()`, while the scope variables have been declared above. 